### PR TITLE
Add totalCount of matching entities to pagination result

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ const { data, cursor } = await paginator.paginate(queryBuilder);
   * `beforeCursor`: the before cursor.
   * `afterCursor`: the after cursor.
 
-**`paginator.paginate(queryBuilder)` returns the entities and cursor for the next iteration**
+**`paginator.paginate(queryBuilder)` returns the entities, cursor for the next iteration, and the totalCount of matching records**
 
 ```typescript
-interface PagingResult<Entity> {
+export interface PagingResult<Entity> {
   data: Entity[];
   cursor: Cursor;
+  totalCount: number | null;
 }
 
 interface Cursor {
@@ -78,7 +79,7 @@ const nextPaginator = buildPaginator({
   },
 });
 
-const { data, cursor } = await nextPaginator.paginate(queryBuilder);
+const { data, cursor, totalCount } = await nextPaginator.paginate(queryBuilder);
 ```
 
 ### Query prev page by `beforeCursor`

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,14 +11,14 @@ export interface PagingQuery {
   order?: Order;
 }
 
-export interface PagniationOtions<Entity> {
+export interface PaginationOptions<Entity> {
   entity: ObjectType<Entity>;
   alias?: string;
   query?: PagingQuery;
   paginationKeys?: Extract<keyof Entity, string>[];
 }
 
-export function buildPaginator<Entity>(options: PagniationOtions<Entity>): Paginator<Entity> {
+export function buildPaginator<Entity>(options: PaginationOptions<Entity>): Paginator<Entity> {
   const {
     entity,
     query = {},

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -12,7 +12,7 @@ describe('TypeORM cursor-based pagination test', () => {
     await createConnection({
       type: 'postgres',
       host: 'localhost',
-      port: 54321,
+      port: 5432,
       username: 'test',
       password: 'test',
       database: 'test',

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -12,7 +12,7 @@ describe('TypeORM cursor-based pagination test', () => {
     await createConnection({
       type: 'postgres',
       host: 'localhost',
-      port: 5432,
+      port: 54321,
       username: 'test',
       password: 'test',
       database: 'test',
@@ -106,7 +106,22 @@ describe('TypeORM cursor-based pagination test', () => {
     expect(result.data).length(10);
   });
 
-  it('should return empty array and null cursor if no data', async () => {
+  it('should return an accurate totalCount of entities matching query', async () => {
+    const queryBuilder = createQueryBuilder();
+    const paginator = buildPaginator({
+      entity: User,
+      query: {
+        limit: 1,
+      },
+    });
+
+    const result = await paginator.paginate(queryBuilder);
+
+    expect(result.data).length(1);
+    expect(result.totalCount).to.eq(10);
+  });
+
+  it('should return empty array, null cursor, and 0 totalCount if no data', async () => {
     const queryBuilder = createQueryBuilder().where('user.id > :id', { id: 10 });
     const paginator = buildPaginator({
       entity: User,
@@ -116,6 +131,7 @@ describe('TypeORM cursor-based pagination test', () => {
     expect(result.data).length(0);
     expect(result.cursor.beforeCursor).to.eq(null);
     expect(result.cursor.afterCursor).to.eq(null);
+    expect(result.totalCount).to.eq(0);
   });
 
   it('should correctly paginate entities with camel-cased pagination keys', async () => {


### PR DESCRIPTION
This PR switches `.getMany()` to `.getManyAndCount()` so that PagingResult can return `totalCount: number | null` of the matching records. Allows consumers to know how many total results there are and therefore calculate how many pages there are total. 

- Added a test to verify
- Fixed a typo in a separate commit (`PagniationOtions` -> `PaginationOptions`) - so this probably needs a version bump?

Is this something you are interested in merging?