### PR TITLE
Export type to make this an isolatedModule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { ObjectType } from 'typeorm';
 
 import Paginator, { Order, Cursor, PagingResult } from './Paginator';
 
-export { Order, Cursor, PagingResult };
+export type { Order, Cursor, PagingResult };
 
 export interface PagingQuery {
   afterCursor?: string;


### PR DESCRIPTION
Without the `type` keyword this export currently throws an error when building with `tsc` and `isolatedModules` set to `true`.