### PR TITLE
fix: missing order from query builder

### DIFF
--- a/src/Paginator.ts
+++ b/src/Paginator.ts
@@ -120,7 +120,11 @@ export default class Paginator<Entity> {
     }
 
     builder.take(this.limit + 1);
-    builder.orderBy(this.buildOrder());
+
+    const paginationKeyOrders = this.buildOrder();
+    Object.keys(paginationKeyOrders).forEach(orderKey => {
+      builder.addOrderBy(orderKey, paginationKeyOrders[orderKey] === 'ASC' ? 'ASC' : 'DESC')
+    });
 
     return builder;
   }


### PR DESCRIPTION
Regarding issue https://github.com/benjamin658/typeorm-cursor-pagination/issues/4 , I made a change that solves missing  `order by` from our query builder in the main query.