### PR TITLE
fix(paginator) allow composite pagination keys with float columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ const { data, cursor } = await paginator.paginate(queryBuilder);
 * `entity` [required]: TypeORM entity.
 * `alias` [optional]: alias of the query builder.
 * `paginationKeys` [optional]: array of the fields to be used for the pagination, **default is `id`**.
+* `paginationUniqueKey` [optional]: field to be used as a unique descriminator for the pagination, **default is `id`**.
 * `query` [optional]:
   * `limit`: limit the number of records returned, **default is 100**.
   * `order`: **ASC** or **DESC**, **default is DESC**.

--- a/src/buildPaginator.ts
+++ b/src/buildPaginator.ts
@@ -14,6 +14,7 @@ export interface PaginationOptions<Entity> {
   alias?: string;
   query?: PagingQuery;
   paginationKeys?: Extract<keyof Entity, string>[];
+  paginationUniqueKey?: Extract<keyof Entity, string>;
 }
 
 export function buildPaginator<Entity>(options: PaginationOptions<Entity>): Paginator<Entity> {
@@ -22,9 +23,10 @@ export function buildPaginator<Entity>(options: PaginationOptions<Entity>): Pagi
     query = {},
     alias = entity.name.toLowerCase(),
     paginationKeys = ['id' as any],
+    paginationUniqueKey = 'id' as any,
   } = options;
 
-  const paginator = new Paginator(entity, paginationKeys);
+  const paginator = new Paginator(entity, paginationKeys, paginationUniqueKey);
 
   paginator.setAlias(alias);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,7 @@ export function decodeByType(type: string, value: string): string | number | Dat
     }
 
     case 'number': {
-      const num = parseInt(value, 10);
+      const num = parseFloat(value);
 
       if (Number.isNaN(num)) {
         throw new Error('number column in cursor should be a valid number');

--- a/test/entities/User.ts
+++ b/test/entities/User.ts
@@ -21,6 +21,12 @@ export class User {
   public name!: string;
 
   @Column({
+    type: 'float',
+    nullable: false,
+  })
+  public balance!: number;
+  
+  @Column({
     type: 'timestamp',
     nullable: false,
   })

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -68,6 +68,31 @@ describe('TypeORM cursor-based pagination test', () => {
     expect(prevPageResult.data[0].id).to.eq(10);
   });
 
+  it('should paginate correctly with a float column in pagination keys', async () => {
+    const queryBuilder = createQueryBuilder(User, 'user');
+    const firstPagePaginator = buildPaginator({
+      entity: User,
+      paginationKeys: ['balance', 'id'],
+      query: {
+        limit: 2,
+      },
+    });
+    const firstPageResult = await firstPagePaginator.paginate(queryBuilder.clone());
+
+    const nextPagePaginator = buildPaginator({
+      entity: User,
+      paginationKeys: ['balance', 'id'],
+      query: {
+        limit: 2,
+        afterCursor: firstPageResult.cursor.afterCursor as string,
+      },
+    });
+    const nextPageResult = await nextPagePaginator.paginate(queryBuilder.clone());
+
+    expect(firstPageResult.data[1].id).to.not.eq(nextPageResult.data[0].id);
+    expect(firstPageResult.data[1].balance).to.be.above(nextPageResult.data[0].balance);
+  });
+
   it('should return entities with given order', async () => {
     const queryBuilder = createQueryBuilder(User, 'user');
     const ascPaginator = buildPaginator({

--- a/test/utils/prepareData.ts
+++ b/test/utils/prepareData.ts
@@ -9,9 +9,16 @@ function setTimestamp(i: number): Date {
   return now;
 }
 
+function getRandomFloat(min: number, max: number): number {
+  const str = (Math.random() * (max - min) + min).toFixed(2);
+
+  return parseFloat(str);
+}
+
 export async function prepareData(): Promise<void> {
   const data = [...Array(10).keys()].map((i) => ({
     name: `user${i}`,
+    balance: getRandomFloat(1, 2),
     camelCaseColumn: setTimestamp(i),
     photos: [
       {


### PR DESCRIPTION
This fix allows advanced pagination keys where the unique column
key doesn't have to be called `id` and can be specified through
a new attribute called `paginationUniqueKey`

`paginationUniqueKey` defaults to `id`

----

Hi,

I had a case where the pagination was wrong with the same entry showing up in the next page. 
The issue was two fold:  

- `decode` was transforming the value stored in the cursor with `parseInt` instead of `parseFloat`. This alone would cause bugs with a float column as the query would look for items greater or lower than the integer value, hence missing entries. 

> Example:

> paginationKeys: [balance, id]
> order: DESC
> first page has the following last entry (balance: 1.55, id: 2)
> query for next page would have balance < 1 instead of balance < 1.55
> ==> missing all potential entries between 1 and 1.55

- `buildCursorQuery` had an incorrect behavior regarding composite pagination keys. 

In a cursor-based pagination, the order of the keys used matters to have a correct ordering.

First, we should always have a key matching a column where values are unique and orderable (`id` is commonly used when it's an auto-increment integer column). This is the responsability to the developper to set a proper one. 

Second, the paginationKeys doesn't always start with that "unique key column". If I want to paginate a set of Users by their account balance, the paginationKeys will be set to ['balance', 'id']. In that case the buildCursorQuery would fail in making a correct SQL query. By correct I mean a working pagination.

This pull request introduces a new optional attribute `paginationUniqueKey` that allows a developer to define the key to use as the "unique key column" which might be necessary in case of composite pagination keys. By default it's set to 'id'.

To sum up:
- [X] Allow float column to be used 
- [X] Fix query in case of composite pagination keys not starting with `id`
- [X] New test case 
- [X] No breaking changes
 
