### PR TITLE
feat(paginator) convert Order type to enum

### DIFF
--- a/src/buildPaginator.ts
+++ b/src/buildPaginator.ts
@@ -6,7 +6,7 @@ export interface PagingQuery {
   afterCursor?: string;
   beforeCursor?: string;
   limit?: number;
-  order?: Order;
+  order?: Order | 'ASC' | 'DESC';
 }
 
 export interface PaginationOptions<Entity> {
@@ -43,7 +43,7 @@ export function buildPaginator<Entity>(options: PaginationOptions<Entity>): Pagi
   }
 
   if (query.order) {
-    paginator.setOrder(query.order);
+    paginator.setOrder(query.order as Order);
   }
 
   return paginator;

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -5,7 +5,7 @@ import { createQueryBuilder } from './utils/createQueryBuilder';
 import { prepareData } from './utils/prepareData';
 import { User } from './entities/User';
 import { Photo } from './entities/Photo';
-import { buildPaginator } from '../src/index';
+import { buildPaginator, Order } from '../src/index';
 
 describe('TypeORM cursor-based pagination test', () => {
   before(async () => {
@@ -106,7 +106,7 @@ describe('TypeORM cursor-based pagination test', () => {
       entity: User,
       query: {
         limit: 1,
-        order: 'DESC',
+        order: Order.DESC,
       },
     });
 

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -91,6 +91,8 @@ describe('TypeORM cursor-based pagination test', () => {
 
     expect(firstPageResult.data[1].id).to.not.eq(nextPageResult.data[0].id);
     expect(firstPageResult.data[1].balance).to.be.above(nextPageResult.data[0].balance);
+    expect(firstPageResult.data[0].id).to.eq(10);
+    expect(nextPageResult.data[0].id).to.eq(8);
   });
 
   it('should return entities with given order', async () => {

--- a/test/utils/prepareData.ts
+++ b/test/utils/prepareData.ts
@@ -9,16 +9,12 @@ function setTimestamp(i: number): Date {
   return now;
 }
 
-function getRandomFloat(min: number, max: number): number {
-  const str = (Math.random() * (max - min) + min).toFixed(2);
-
-  return parseFloat(str);
-}
+const balances = [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2];
 
 export async function prepareData(): Promise<void> {
   const data = [...Array(10).keys()].map((i) => ({
     name: `user${i}`,
-    balance: getRandomFloat(1, 2),
+    balance: balances[i],
     camelCaseColumn: setTimestamp(i),
     photos: [
       {


### PR DESCRIPTION
Avoid using string literals while allowing a developer to use
the type at runtime as an enum

- [x] Tests are passing with a small update to check both usage (literal string like `ASC` and enum type like `Order.ASC`)
- [x] No breaking changes
- [x] Make Order type available as enum at runtime

---

Hi!

I made a small change converting the Order type into an Enum. It allows a better use of the type in my opinion. With that feature, I'm able to do the following in my DTO:

```ts
import { IsInt,  } from 'class-validator';
import { Order } from 'typeorm-cursor-pagination';
import { ApiProperty } from '@nestjs/swagger';

export class PaginationDto<Entity> {
  // ...

  @IsIn(Object.values(Order))
  @ApiProperty({
    enum: Order,
  })
  order: Order = Order.DESC;

}

``` 

instead of

```ts
import { IsInt,  } from 'class-validator';
import { Order } from 'typeorm-cursor-pagination';
import { ApiProperty } from '@nestjs/swagger';

export class PaginationDto<Entity> {
  // ...

  @IsIn(['ASC', 'DESC'])
  @ApiProperty({
    enum: ['ASC', 'DESC'],
  })
  order: Order = 'DESC';

}

``` 
