### PR TITLE
chore: extends ObjectLiteral to meet SelectQueryBuilder generic

### DIFF
--- a/src/Paginator.ts
+++ b/src/Paginator.ts
@@ -1,5 +1,6 @@
 import {
   Brackets,
+  ObjectLiteral,
   ObjectType,
   OrderByCondition,
   SelectQueryBuilder,
@@ -35,7 +36,7 @@ export interface PagingResult<Entity> {
   cursor: Cursor;
 }
 
-export default class Paginator<Entity> {
+export default class Paginator<Entity extends ObjectLiteral> {
   private afterCursor: string | null = null;
 
   private beforeCursor: string | null = null;

--- a/src/buildPaginator.ts
+++ b/src/buildPaginator.ts
@@ -1,4 +1,4 @@
-import { ObjectType } from 'typeorm';
+import { ObjectLiteral, ObjectType } from 'typeorm';
 
 import Paginator, { Order } from './Paginator';
 
@@ -16,7 +16,9 @@ export interface PaginationOptions<Entity> {
   paginationKeys?: Extract<keyof Entity, string>[];
 }
 
-export function buildPaginator<Entity>(options: PaginationOptions<Entity>): Paginator<Entity> {
+export function buildPaginator<Entity extends ObjectLiteral>(
+  options: PaginationOptions<Entity>,
+): Paginator<Entity> {
   const {
     entity,
     query = {},

--- a/test/utils/createQueryBuilder.ts
+++ b/test/utils/createQueryBuilder.ts
@@ -1,7 +1,13 @@
-import { getConnection, SelectQueryBuilder, ObjectType } from 'typeorm';
+import {
+  getConnection,
+  SelectQueryBuilder,
+  ObjectType,
+  ObjectLiteral,
+} from 'typeorm';
 
-export function createQueryBuilder<T>(entity: ObjectType<T>, alias: string): SelectQueryBuilder<T> {
-  return getConnection()
-    .getRepository(entity)
-    .createQueryBuilder(alias);
+export function createQueryBuilder<T extends ObjectLiteral>(
+  entity: ObjectType<T>,
+  alias: string,
+): SelectQueryBuilder<T> {
+  return getConnection().getRepository(entity).createQueryBuilder(alias);
 }


### PR DESCRIPTION
Hi, I was just looking into this awesome library and found a tiny typescript error.

I made a trivial change to let it meet generic type of SelectQueryBuilder(from TypeORM).

