### PR TITLE
Support null/undefined numbers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,6 +50,11 @@ export function decodeByType(type: string, value: string): string | number | Dat
     }
 
     case 'number': {
+      // Support null/undefined columns
+      if (value == null) {
+        return value;
+      }
+      
       const num = parseFloat(value);
 
       if (Number.isNaN(num)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export function decodeByType(type: string, value: string): string | number | Dat
 
     case 'number': {
       // Support null/undefined columns
-      if (value == null) {
+      if (value == null || value === 'null') {
         return value;
       }
       


### PR DESCRIPTION
We store some columns as null in the database. If you throw for nan for these rows it breaks sorting.